### PR TITLE
perf(dotnet): configurable bounded concurrency for WebSocket sends

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -16,6 +16,10 @@ on:
         description: 'Max connections ceiling for perf test'
         required: false
         default: '5000'
+      ws_max_pending_sends:
+        description: 'Max pending WebSocket sends per connection (C# only, 0=unlimited)'
+        required: false
+        default: '100'
   push:
     branches:
       - feature/11-dotnet-server
@@ -256,6 +260,7 @@ jobs:
           SERVER_TYPE: ${{ github.event.inputs.server_type }}
           SERVER_PORT: ${{ github.event.inputs.server_type == 'csharp' && '8090' || '8080' }}
           PERF_MAX_CONNECTIONS: ${{ github.event.inputs.max_connections }}
+          WS_MAX_PENDING_SENDS_PER_CONNECTION: ${{ github.event.inputs.ws_max_pending_sends }}
 
       - name: Upload perf results
         uses: actions/upload-artifact@v4

--- a/docs/architecture/SERVER_PERFORMANCE.md
+++ b/docs/architecture/SERVER_PERFORMANCE.md
@@ -34,6 +34,83 @@ Document any server-side caps or configuration limits that affect performance:
 - Payload size limits
 - Storage constraints
 
+## Performance Tuning (.NET Server)
+
+The .NET server includes configurable parameters that allow operators to tune performance based on their hardware and workload characteristics.
+
+### WebSocket Backpressure Configuration
+
+**Environment Variable:** `WS_MAX_PENDING_SENDS_PER_CONNECTION`  
+**Default:** `100`  
+**Range:** `0` (unlimited) to `int.MaxValue`
+
+This setting controls the maximum number of pending WebSocket send operations per connection before backpressure is applied. When the limit is reached, new sends are dropped (with debug logging) until pending sends complete.
+
+#### How It Works
+
+The .NET WebSocket implementation requires serialized sends (only one `SendAsync` at a time per socket). The server uses a fire-and-forget pattern with a semaphore to bound the number of concurrent pending sends:
+
+```
+Client Request → Serialize → Acquire Semaphore → Queue SendAsync → Release on Complete
+                                    ↓
+                          (if semaphore full, drop message)
+```
+
+#### Configuration Tradeoffs
+
+| Value | Latency Impact | Message Loss | Memory Usage | Best For |
+|-------|---------------|--------------|--------------|----------|
+| `50` | Lowest P95 under load | Higher drop rate under burst | Lowest | Latency-sensitive apps |
+| `100` (default) | Balanced | Moderate | Moderate | General purpose |
+| `200-500` | Higher P95 under sustained load | Lower drop rate | Higher | Burst-tolerant apps |
+| `0` (unlimited) | Can spike to seconds | None | Unbounded | Testing only |
+
+#### Benchmark Results
+
+The following results were captured on GitHub Actions runners (AMD EPYC 7763, 4 cores, 16GB RAM) with 30,000 connections:
+
+<!-- TUNING_TABLE_START -->
+| WS_MAX_PENDING_SENDS | P95 @ 50% | P95 @ 80% | P95 @ Max | Avg Semaphore Wait | Max Pending |
+|---------------------|-----------|-----------|-----------|-------------------|-------------|
+| 50 | TBD | TBD | TBD | TBD | TBD |
+| 100 | 51ms | 160ms | 1,639ms | 15µs | 153 |
+| 200 | TBD | TBD | TBD | TBD | TBD |
+| 500 | TBD | TBD | TBD | TBD | TBD |
+| 0 (unlimited/baseline) | 51ms | 155ms | 1,861ms | 22,720µs | 13,103 |
+<!-- TUNING_TABLE_END -->
+
+#### Recommendations
+
+1. **Start with the default (100)** - Provides good balance for most workloads
+2. **Monitor `SendDropped` metrics** - If you see drops in production, consider increasing the limit
+3. **Monitor P95 latency** - If latency spikes under load, consider decreasing the limit
+4. **Never use `0` in production** - Unbounded queues can cause memory exhaustion and multi-second latencies
+
+#### Setting the Value
+
+**Environment variable:**
+```bash
+WS_MAX_PENDING_SENDS_PER_CONNECTION=200 dotnet run
+```
+
+**appsettings.json:**
+```json
+{
+  "SyncKit": {
+    "WsMaxPendingSendsPerConnection": 200
+  }
+}
+```
+
+**GitHub Actions workflow dispatch:**
+```bash
+gh workflow run perf-benchmark.yml \
+  --ref perf/option1-bounded-concurrency \
+  -f server_type=csharp \
+  -f max_connections=30000 \
+  -f ws_max_pending_sends=200
+```
+
 ## Running Performance Tests
 
 ### Local Execution

--- a/docs/architecture/SERVER_PERFORMANCE.md
+++ b/docs/architecture/SERVER_PERFORMANCE.md
@@ -8,7 +8,7 @@ This document summarizes performance discovery benchmarks for SyncKit server imp
 | Server | OS | CPU | RAM (GB) | Runtime | Captured |
 |--------|----|-----|----------|---------|----------|
 | TypeScript | linux 6.11.0-1018-azure | Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz (4 cores) | 16 | Bun 1.3.6 | 2026-01-17T21:53:14.057Z |
-| C# | linux 6.11.0-1018-azure | AMD EPYC 7763 64-Core Processor (4 cores) | 16 | Bun 1.3.6 | 2026-01-21T13:29:26.618Z |
+| C# | linux 6.11.0-1018-azure | AMD EPYC 7763 64-Core Processor (4 cores) | 16 | Bun 1.3.6 | 2026-01-21T14:36:30.057Z |
 <!-- PERF_ENV_END -->
 
 ## Performance Summary (Auto-Generated)
@@ -18,8 +18,8 @@ This document summarizes performance discovery benchmarks for SyncKit server imp
 |--------|------------|-----|------|
 | Max Concurrent Connections | 30,001 | 30,001 | connections |
 | Max Ops/Sec (Single Client) | 1,000 | 1,000 | ops/sec |
-| Max Ops/Sec (Aggregate) | 2,000 | 1,799 | ops/sec |
-| P95 Latency | 51 | 1,861 | ms |
+| Max Ops/Sec (Aggregate) | 2,000 | 1,771 | ops/sec |
+| P95 Latency | 51 | 1,639 | ms |
 | Memory Growth | 3.95 | 0.00 | MB/min |
 
 *Last updated: 2026-01-17T21:53:14.057Z*

--- a/docs/architecture/SERVER_PERFORMANCE.md
+++ b/docs/architecture/SERVER_PERFORMANCE.md
@@ -72,19 +72,24 @@ The following results were captured on GitHub Actions runners (AMD EPYC 7763, 4 
 <!-- TUNING_TABLE_START -->
 | WS_MAX_PENDING_SENDS | P95 @ 50% | P95 @ 80% | P95 @ Max | Avg Semaphore Wait | Max Pending |
 |---------------------|-----------|-----------|-----------|-------------------|-------------|
-| 50 | TBD | TBD | TBD | TBD | TBD |
-| 100 | 51ms | 160ms | 1,639ms | 15µs | 153 |
-| 200 | TBD | TBD | TBD | TBD | TBD |
-| 500 | TBD | TBD | TBD | TBD | TBD |
+| 50 | 51ms | 142ms | 1,405ms | 15,364µs | 1,200 |
+| 100 (default) | 51ms | 160ms | 1,639ms | 15µs | 153 |
+| 200 | 52ms | 181ms | 1,572ms | 2,483µs | 300 |
+| 500 | 51ms | 120ms | 1,563ms | 22µs | 226 |
 | 0 (unlimited/baseline) | 51ms | 155ms | 1,861ms | 22,720µs | 13,103 |
 <!-- TUNING_TABLE_END -->
 
-#### Recommendations
+**Key Observations:**
 
-1. **Start with the default (100)** - Provides good balance for most workloads
-2. **Monitor `SendDropped` metrics** - If you see drops in production, consider increasing the limit
-3. **Monitor P95 latency** - If latency spikes under load, consider decreasing the limit
-4. **Never use `0` in production** - Unbounded queues can cause memory exhaustion and multi-second latencies
+1. **All bounded values outperform unlimited** - The baseline (0/unlimited) has the worst P95 @ Max (1,861ms) due to unbounded task accumulation causing 22.7ms average semaphore waits.
+
+2. **50 achieves lowest P95 @ Max (1,405ms)** - But shows degraded semaphore wait under extreme load (15,364µs avg), suggesting the limit is too aggressive and causes backpressure-induced retries.
+
+3. **500 provides excellent balance** - Only 22µs avg semaphore wait with 1,563ms P95 @ Max. The higher limit absorbs burst traffic without causing contention.
+
+4. **100 (default) is conservative** - Good for memory-constrained environments but may not be optimal for high-throughput scenarios.
+
+**Recommendation:** For most production workloads on modern hardware (4+ cores, 8GB+ RAM), consider **200-500** for better burst handling. Use **50-100** only if memory is constrained or you prefer to drop messages early rather than queue them.
 
 #### Setting the Value
 

--- a/server/csharp/src/SyncKit.Server/Configuration/ConfigurationExtensions.cs
+++ b/server/csharp/src/SyncKit.Server/Configuration/ConfigurationExtensions.cs
@@ -89,6 +89,9 @@ public static class ConfigurationExtensions
                 if (int.TryParse(Environment.GetEnvironmentVariable("WS_MAX_CONNECTIONS"), out var maxConnections))
                     config.WsMaxConnections = maxConnections;
 
+                if (int.TryParse(Environment.GetEnvironmentVariable("WS_MAX_PENDING_SENDS_PER_CONNECTION"), out var maxPendingSends))
+                    config.WsMaxPendingSendsPerConnection = maxPendingSends;
+
                 // Sync
                 if (int.TryParse(Environment.GetEnvironmentVariable("SYNC_BATCH_SIZE"), out var batchSize))
                     config.SyncBatchSize = batchSize;

--- a/server/csharp/src/SyncKit.Server/Configuration/SyncKitConfig.cs
+++ b/server/csharp/src/SyncKit.Server/Configuration/SyncKitConfig.cs
@@ -145,6 +145,17 @@ public class SyncKitConfig
     [Range(0, int.MaxValue)]
     public int WsConnectionCreationConcurrency { get; set; } = 0;
 
+    /// <summary>
+    /// Maximum pending WebSocket sends per connection before backpressure is applied.
+    /// Controls the trade-off between latency and memory usage under high load.
+    /// Lower values (50-100): Better latency stability, may drop messages under burst load.
+    /// Higher values (200-500): Handles larger bursts, but may increase latency under sustained load.
+    /// Set to 0 for unlimited (not recommended for production).
+    /// Environment variable: WS_MAX_PENDING_SENDS_PER_CONNECTION
+    /// </summary>
+    [Range(0, int.MaxValue)]
+    public int WsMaxPendingSendsPerConnection { get; set; } = 100;
+
     // Sync
     /// <summary>
     /// Number of operations to batch together for sync.

--- a/server/csharp/src/SyncKit.Server/WebSockets/ConnectionManager.cs
+++ b/server/csharp/src/SyncKit.Server/WebSockets/ConnectionManager.cs
@@ -103,7 +103,8 @@ public class ConnectionManager : IConnectionManager
                 connectionId,
                 jsonHandler,
                 binaryHandler,
-                connectionLogger);
+                connectionLogger,
+                _config.WsMaxPendingSendsPerConnection);
 
             // Track the connection
             if (!_connections.TryAdd(connectionId, connection))

--- a/tests/perf/test-ci-rate.ts
+++ b/tests/perf/test-ci-rate.ts
@@ -1,0 +1,27 @@
+import { runOpsMeasurement } from './ops-utils';
+import { computeLatencyStats } from '../helpers/metrics';
+
+const serverUrl = process.env.SYNCKIT_SERVER_URL || 'http://localhost:8090';
+
+async function main() {
+  console.log(`Testing at 2000 ops/sec against ${serverUrl}...`);
+  
+  const result = await runOpsMeasurement({
+    serverUrl,
+    senderCount: 4,
+    receiverCount: 2,
+    opsPerSec: 2000,
+    durationSec: 8,
+  });
+  
+  const stats = computeLatencyStats(result.latenciesMs);
+  console.log('Results:');
+  console.log('  Sent:', result.sent);
+  console.log('  Converged:', result.convergedWithin1s);
+  console.log('  Convergence Rate:', (result.convergenceRate * 100).toFixed(1) + '%');
+  console.log('  P50:', stats.p50 + 'ms');
+  console.log('  P95:', stats.p95 + 'ms');
+  console.log('  P99:', stats.p99 + 'ms');
+}
+
+main().catch(console.error);

--- a/tests/run-perf-benchmark.sh
+++ b/tests/run-perf-benchmark.sh
@@ -21,6 +21,11 @@ if [[ "$SERVER_TYPE" == "csharp" ]]; then
   SERVER_PORT=${SERVER_PORT:-8090}
   ensure_port_free "$SERVER_PORT"
   echo "Starting C# server on port ${SERVER_PORT}..."
+  # Pass through WS_MAX_PENDING_SENDS_PER_CONNECTION if set (defaults to 100 in server)
+  WS_MAX_PENDING=${WS_MAX_PENDING_SENDS_PER_CONNECTION:-}
+  if [[ -n "$WS_MAX_PENDING" ]]; then
+    echo "  WS_MAX_PENDING_SENDS_PER_CONNECTION=${WS_MAX_PENDING}"
+  fi
   (
     cd "${ROOT_DIR}/server/csharp/src/SyncKit.Server"
     # CRITICAL: Use Production environment to disable Debug logging (causes 261x latency penalty)
@@ -28,6 +33,7 @@ if [[ "$SERVER_TYPE" == "csharp" ]]; then
     SYNCKIT_SERVER_URL="http://0.0.0.0:${SERVER_PORT}" \
     SYNCKIT_AUTH_REQUIRED=false \
     JWT_SECRET='test-secret-key-for-integration-tests-only-32-chars' \
+    WS_MAX_PENDING_SENDS_PER_CONNECTION="${WS_MAX_PENDING}" \
     dotnet run --configuration Release --no-build --no-launch-profile
   ) &
   SERVER_PID=$!


### PR DESCRIPTION
## Summary

- Adds `WS_MAX_PENDING_SENDS_PER_CONNECTION` config to control backpressure threshold
- Fixes unbounded fire-and-forget task accumulation that caused P95 latency degradation under load
- Includes CI benchmark workflow support and performance tuning documentation

## Root Cause

Under high load, each `Send()` spawned a fire-and-forget task waiting on a `SemaphoreSlim(1,1)` to serialize WebSocket sends. With unlimited queuing, this caused:
- 22,720µs avg semaphore wait at max load
- 13,103 pending send tasks backed up
- 1,861ms P95 latency at max connections

## Solution

Bounded concurrency with configurable limit (default: 100). When limit is reached, new sends are dropped and logged.

## Benchmark Results (CI: AMD EPYC 7763, 4 cores, 30K connections)

| WS_MAX_PENDING_SENDS | P95 @ 50% | P95 @ 80% | P95 @ Max | Avg Sem Wait | Max Pending |
|---------------------|-----------|-----------|-----------|--------------|-------------|
| 50 | 51ms | 142ms | 1,405ms | 15,364µs | 1,200 |
| 100 (default) | 51ms | 160ms | 1,639ms | 15µs | 153 |
| 200 | 52ms | 181ms | 1,572ms | 2,483µs | 300 |
| 500 | 51ms | 120ms | 1,563ms | 22µs | 226 |
| 0 (unlimited) | 51ms | 155ms | 1,861ms | 22,720µs | 13,103 |

**Recommendation:** 200-500 for production workloads; 100 for memory-constrained environments.

## Changes

- `Connection.cs`: Bounded concurrency with configurable `_pendingSendLimit`
- `SyncKitConfig.cs`: Added `WsMaxPendingSendsPerConnection` property
- `ConfigurationExtensions.cs`: Added env var override
- `ConnectionManager.cs`: Passes config to Connection constructor
- `run-perf-benchmark.sh`: Passes through env var
- `perf-benchmark.yml`: Added `ws_max_pending_sends` workflow input
- `SERVER_PERFORMANCE.md`: Added tuning guide with benchmark results